### PR TITLE
[TASK] Support variables and suffix in routes via settings

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Configuration/ConfigurationManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Configuration/ConfigurationManager.php
@@ -763,13 +763,18 @@ EOD;
         $sortedRouteSettings = (new PositionalArraySorter($routeSettings))->toArray();
         foreach ($sortedRouteSettings as $packageKey => $routeFromSettings) {
             $subRoutesName = $packageKey . 'SubRoutes';
+            $subRoutesConfiguration = ['package' => $packageKey];
+            if (isset($routeFromSettings['variables'])) {
+                $subRoutesConfiguration['variables'] = $routeFromSettings['variables'];
+            }
+            if (isset($routeFromSettings['suffix'])) {
+                $subRoutesConfiguration['suffix'] = $routeFromSettings['suffix'];
+            }
             $routeDefinitions[] = [
                 'name' => $packageKey,
                 'uriPattern' => '<' . $subRoutesName . '>',
                 'subRoutes' => [
-                    $subRoutesName => [
-                        'package' => $packageKey,
-                    ]
+                    $subRoutesName => $subRoutesConfiguration
                 ]
             ];
         }


### PR DESCRIPTION
Adds support for the `variables` and `suffix` sub route configuration options
in routes via settings.

Related: FLOW-411
